### PR TITLE
fix(package-lock.json) update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,1248 +5,25 @@
   "requires": true,
   "dependencies": {
     "@stencil/core": {
-      "version": "0.0.6-10",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.0.6-10.tgz",
-      "integrity": "sha512-w7axEBwBJSbJQlXvUeIdFsoRVoN2KF8gMfPGmG28sIfDWK+vQgtEJ4rMl8VQKTW2kUg5w/cTy589OF0ws3ojlg==",
+      "version": "0.0.8-2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.0.8-2.tgz",
+      "integrity": "sha512-EpUPh6JDXvoTNgCYfZ+SytWpAZuffqpNKcA5oX4+rxqKI6dsr8KjOm8522p20cH4eJ1BY7BQ/0Lej7SQ+FwCoQ==",
       "requires": {
-        "chalk": "2.1.0",
         "chokidar": "1.7.0",
-        "clean-css": "4.1.9",
-        "glob": "7.1.2",
-        "is-glob": "4.0.0",
-        "jsdom": "11.2.0",
-        "minimist": "1.2.0",
-        "node-fetch": "1.7.3",
+        "jsdom": "11.3.0",
         "node-sass": "4.5.3",
         "rollup": "0.50.0",
-        "rollup-plugin-commonjs": "8.2.0",
+        "rollup-plugin-commonjs": "8.2.5",
         "rollup-plugin-node-resolve": "3.0.0",
-        "typescript": "2.5.3",
-        "uglify-es": "3.1.2",
-        "workbox-build": "2.0.3"
+        "typescript": "2.6.1",
+        "uglify-es": "3.1.6",
+        "workbox-build": "2.1.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "6.0.88",
-          "bundled": true
-        },
-        "abab": {
-          "version": "1.0.4",
-          "bundled": true
-        },
-        "acorn": {
-          "version": "4.0.13",
-          "bundled": true
-        },
-        "acorn-globals": {
-          "version": "3.1.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "4.0.13"
-          }
-        },
-        "ajv": {
-          "version": "5.2.3",
-          "bundled": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "ansi-styles": {
-          "version": "3.2.0",
-          "bundled": true,
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "arr-flatten": "1.1.0"
-          }
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "bundled": true
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "bundled": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "boom": {
-          "version": "4.3.1",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.8",
-          "bundled": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "braces": {
-          "version": "1.8.5",
-          "bundled": true,
-          "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
-          }
-        },
-        "browser-resolve": {
-          "version": "1.11.2",
-          "bundled": true,
-          "requires": {
-            "resolve": "1.1.7"
-          },
-          "dependencies": {
-            "resolve": {
-              "version": "1.1.7",
-              "bundled": true
-            }
-          }
-        },
-        "builtin-modules": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true
-        },
-        "chalk": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
-          }
-        },
-        "clean-css": {
-          "version": "4.1.9",
-          "bundled": true,
-          "requires": {
-            "source-map": "0.5.7"
-          }
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true
-        },
-        "color-convert": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "bundled": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "bundled": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true
-        },
-        "content-type-parser": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "bundled": true,
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "bundled": true
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "bundled": true,
-          "requires": {
-            "cssom": "0.3.2"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "deep-is": {
-          "version": "0.1.3",
-          "bundled": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "encoding": {
-          "version": "0.1.12",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.13"
-          }
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "escodegen": {
-          "version": "1.9.0",
-          "bundled": true,
-          "requires": {
-            "esprima": "3.1.3",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "optionator": "0.8.2",
-            "source-map": "0.5.7"
-          }
-        },
-        "esprima": {
-          "version": "3.1.3",
-          "bundled": true
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "estree-walker": {
-          "version": "0.5.0",
-          "bundled": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "bundled": true
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "is-posix-bracket": "0.1.1"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "bundled": true,
-          "requires": {
-            "fill-range": "2.2.3"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "is-extglob": "1.0.0"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "bundled": true
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "fast-levenshtein": {
-          "version": "2.0.6",
-          "bundled": true
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "bundled": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "bundled": true,
-          "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "bundled": true,
-          "requires": {
-            "for-in": "1.0.2"
-          }
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "bundled": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "fs-extra": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "3.0.1",
-            "universalify": "0.1.1"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "glob-base": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "is-glob": "2.0.1"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            }
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "har-validator": {
-          "version": "5.0.3",
-          "bundled": true,
-          "requires": {
-            "ajv": "5.2.3",
-            "har-schema": "2.0.0"
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.0.2"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "bundled": true
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "whatwg-encoding": "1.0.1"
-          }
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.13",
-          "bundled": true
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "is-buffer": {
-          "version": "1.1.5",
-          "bundled": true
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "bundled": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "bundled": true,
-          "requires": {
-            "is-primitive": "2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "is-extglob": {
-          "version": "2.1.1",
-          "bundled": true
-        },
-        "is-glob": {
-          "version": "4.0.0",
-          "bundled": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
-        },
-        "is-module": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "bundled": true
-        },
-        "is-stream": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "bundled": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "optional": true
-        },
-        "jsdom": {
-          "version": "11.2.0",
-          "bundled": true,
-          "requires": {
-            "abab": "1.0.4",
-            "acorn": "4.0.13",
-            "acorn-globals": "3.1.0",
-            "array-equal": "1.0.0",
-            "content-type-parser": "1.0.1",
-            "cssom": "0.3.2",
-            "cssstyle": "0.2.37",
-            "escodegen": "1.9.0",
-            "html-encoding-sniffer": "1.0.1",
-            "nwmatcher": "1.4.2",
-            "parse5": "3.0.2",
-            "pn": "1.0.0",
-            "request": "2.83.0",
-            "request-promise-native": "1.0.5",
-            "sax": "1.2.4",
-            "symbol-tree": "3.2.2",
-            "tough-cookie": "2.3.3",
-            "webidl-conversions": "4.0.2",
-            "whatwg-encoding": "1.0.1",
-            "whatwg-url": "6.3.0",
-            "xml-name-validator": "2.0.1"
-          }
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "bundled": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "jsonfile": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "bundled": true,
-          "requires": {
-            "is-buffer": "1.1.5"
-          }
-        },
-        "levn": {
-          "version": "0.3.0",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "bundled": true
-        },
-        "lodash._reinterpolate": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "lodash.sortby": {
-          "version": "4.7.0",
-          "bundled": true
-        },
-        "lodash.template": {
-          "version": "4.4.0",
-          "bundled": true,
-          "requires": {
-            "lodash._reinterpolate": "3.0.0",
-            "lodash.templatesettings": "4.1.0"
-          }
-        },
-        "lodash.templatesettings": {
-          "version": "4.1.0",
-          "bundled": true,
-          "requires": {
-            "lodash._reinterpolate": "3.0.0"
-          }
-        },
-        "magic-string": {
-          "version": "0.22.4",
-          "bundled": true,
-          "requires": {
-            "vlq": "0.2.3"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "bundled": true,
-          "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.30.0",
-          "bundled": true
-        },
-        "mime-types": {
-          "version": "2.1.17",
-          "bundled": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "bundled": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "bundled": true
-            }
-          }
-        },
-        "node-fetch": {
-          "version": "1.7.3",
-          "bundled": true,
-          "requires": {
-            "encoding": "0.1.12",
-            "is-stream": "1.1.0"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
-        },
-        "nwmatcher": {
-          "version": "1.4.2",
-          "bundled": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
-          }
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "bundled": true,
-          "requires": {
-            "deep-is": "0.1.3",
-            "fast-levenshtein": "2.0.6",
-            "levn": "0.3.0",
-            "prelude-ls": "1.1.2",
-            "type-check": "0.3.2",
-            "wordwrap": "1.0.0"
-          }
-        },
-        "parse-glob": {
-          "version": "3.0.4",
-          "bundled": true,
-          "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
-          },
-          "dependencies": {
-            "is-extglob": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "is-glob": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "1.0.0"
-              }
-            }
-          }
-        },
-        "parse5": {
-          "version": "3.0.2",
-          "bundled": true,
-          "requires": {
-            "@types/node": "6.0.88"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "bundled": true
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "bundled": true
-        },
-        "pn": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "prelude-ls": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "bundled": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true
-        },
-        "qs": {
-          "version": "6.5.1",
-          "bundled": true
-        },
-        "randomatic": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "requires": {
-                    "is-buffer": "1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-buffer": "1.1.5"
-              }
-            }
-          }
-        },
-        "regex-cache": {
-          "version": "0.4.4",
-          "bundled": true,
-          "requires": {
-            "is-equal-shallow": "0.1.3"
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "bundled": true
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "bundled": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "bundled": true
-        },
-        "request": {
-          "version": "2.83.0",
-          "bundled": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "request-promise-core": {
-          "version": "1.1.1",
-          "bundled": true,
-          "requires": {
-            "lodash": "4.17.4"
-          }
-        },
-        "request-promise-native": {
-          "version": "1.0.5",
-          "bundled": true,
-          "requires": {
-            "request-promise-core": "1.1.1",
-            "stealthy-require": "1.1.1",
-            "tough-cookie": "2.3.3"
-          }
-        },
-        "resolve": {
-          "version": "1.4.0",
-          "bundled": true,
-          "requires": {
-            "path-parse": "1.0.5"
-          }
-        },
-        "rollup": {
-          "version": "0.50.0",
-          "bundled": true
-        },
-        "rollup-plugin-commonjs": {
-          "version": "8.2.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.1.2",
-            "estree-walker": "0.5.0",
-            "magic-string": "0.22.4",
-            "resolve": "1.4.0",
-            "rollup-pluginutils": "2.0.1"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "5.1.2",
-              "bundled": true
-            }
-          }
-        },
-        "rollup-plugin-node-resolve": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "browser-resolve": "1.11.2",
-            "builtin-modules": "1.1.1",
-            "is-module": "1.0.0",
-            "resolve": "1.4.0"
-          }
-        },
-        "rollup-pluginutils": {
-          "version": "2.0.1",
-          "bundled": true,
-          "requires": {
-            "estree-walker": "0.3.1",
-            "micromatch": "2.3.11"
-          },
-          "dependencies": {
-            "estree-walker": {
-              "version": "0.3.1",
-              "bundled": true
-            }
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true
-        },
-        "sntp": {
-          "version": "2.0.2",
-          "bundled": true,
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "bundled": true
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "bundled": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "stealthy-require": {
-          "version": "1.1.1",
-          "bundled": true
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "4.4.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "bundled": true
-        },
-        "tough-cookie": {
-          "version": "2.3.3",
-          "bundled": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tr46": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "punycode": "2.1.0"
-          },
-          "dependencies": {
-            "punycode": {
-              "version": "2.1.0",
-              "bundled": true
-            }
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "optional": true
-        },
-        "type-check": {
-          "version": "0.3.2",
-          "bundled": true,
-          "requires": {
-            "prelude-ls": "1.1.2"
-          }
-        },
-        "uglify-es": {
-          "version": "3.1.2",
-          "bundled": true,
-          "requires": {
-            "commander": "2.11.0",
-            "source-map": "0.5.7"
-          }
-        },
-        "universalify": {
-          "version": "0.1.1",
-          "bundled": true
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "bundled": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "bundled": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
-        },
-        "vlq": {
-          "version": "0.2.3",
-          "bundled": true
-        },
-        "webidl-conversions": {
-          "version": "4.0.2",
-          "bundled": true
-        },
-        "whatwg-encoding": {
-          "version": "1.0.1",
-          "bundled": true,
-          "requires": {
-            "iconv-lite": "0.4.13"
-          }
-        },
-        "whatwg-url": {
-          "version": "6.3.0",
-          "bundled": true,
-          "requires": {
-            "lodash.sortby": "4.7.0",
-            "tr46": "1.0.1",
-            "webidl-conversions": "4.0.2"
-          }
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "workbox-build": {
-          "version": "2.0.3",
-          "bundled": true,
-          "requires": {
-            "chalk": "1.1.3",
-            "fs-extra": "3.0.1",
-            "glob": "7.1.2",
-            "lodash.template": "4.4.0",
-            "mkdirp": "0.5.1",
-            "workbox-sw": "2.0.3"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "chalk": {
-              "version": "1.1.3",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
-            }
-          }
-        },
-        "workbox-sw": {
-          "version": "2.0.3",
-          "bundled": true
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "bundled": true
+        "typescript": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+          "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE="
         }
       }
     },
@@ -1263,9 +40,9 @@
       }
     },
     "@stencil/router": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@stencil/router/-/router-0.0.16.tgz",
-      "integrity": "sha512-SahcEn72tPpkbKGtoBaB8Vcx+cwsliljXCG6X3DimzrlmJ6j7lgmfWnwVN5nuV5DiRNMFIJM4tNkCs1t08FRMA==",
+      "version": "0.0.17",
+      "resolved": "https://registry.npmjs.org/@stencil/router/-/router-0.0.17.tgz",
+      "integrity": "sha512-wocJYxnaPem63Q6gQfBtkjyWSoujMsTDEMJy2LZ58UIyD56qcvOe61hT8H2OpM3F54tSQAsJafcHu2F2HmG0OQ==",
       "requires": {
         "path-to-regexp": "1.7.0"
       }
@@ -1277,16 +54,20 @@
       "dev": true
     },
     "@types/jest": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.1.tgz",
-      "integrity": "sha512-PkhRLvgERKS5ZDrmYUQbbEOwhD4c2vGpWbCvwPLF82cdE6jWAwMKGAWYyIKfEgSDO5tr1p1n2XmeVlynMJ2usA==",
+      "version": "21.1.6",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-21.1.6.tgz",
+      "integrity": "sha512-/qrwhjCeZ8vZy/TPXm56A3baMMUDPfUMkhOGZP3M7dgPCGPZSX/zSieM7jYPuhX3kMcMfsYuvsFIt23u7Ypu2g==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "8.0.52",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.52.tgz",
+      "integrity": "sha512-wOU/VRodnI/4Chxuu6R6bcyN9aE3rztO0i8R76PZO7+DxTXWy60nseGN4ujspucmxrfj5mzgCYPXiXqrD6KC3Q=="
     },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
-      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0=",
-      "dev": true
+      "integrity": "sha1-uB3l9ydOxOdW15fNg08wNkJyTl0="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -1406,8 +187,7 @@
     "array-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
-      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
-      "dev": true
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-find-index": {
       "version": "1.0.2",
@@ -1761,7 +541,6 @@
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
       "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -1769,8 +548,7 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
@@ -1907,6 +685,11 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1920,8 +703,7 @@
     "content-type-parser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
-      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ=",
-      "dev": true
+      "integrity": "sha1-w+VpiMU8ZRJ/tG1AMqOpACRv3JQ="
     },
     "continuable-cache": {
       "version": "0.3.1",
@@ -1966,14 +748,12 @@
     "cssom": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
-      "dev": true
+      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs="
     },
     "cssstyle": {
       "version": "0.2.37",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-      "dev": true,
       "requires": {
         "cssom": "0.3.2"
       }
@@ -2018,8 +798,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -2054,6 +833,11 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
       "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
+    },
+    "domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.0.tgz",
+      "integrity": "sha512-WpwuBlZ2lQRFa4H/4w49deb9rJLot9KmqrKKjMc9qBl7CID+DdC2swoa34ccRl+anL2B6bLp6TjFdIdnzekMBQ=="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -2133,11 +917,15 @@
       "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.5.0.tgz",
+      "integrity": "sha512-/bEAy+yKAZQrEWUhGmS3H9XpGqSDBtRzX0I2PgMw9kA2n1jN22uV5B5p7MFdZdvWdXCRJztXAfx6ZeRfgkEETg=="
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "exec-sh": {
       "version": "0.2.1",
@@ -2235,11 +1023,20 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fast-deep-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -2321,6 +1118,16 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
+      }
+    },
+    "fs-extra": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+      "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "jsonfile": "3.0.1",
+        "universalify": "0.1.1"
       }
     },
     "fs.realpath": {
@@ -3398,7 +2205,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-      "dev": true,
       "requires": {
         "whatwg-encoding": "1.0.1"
       }
@@ -3422,8 +2228,7 @@
     "iconv-lite": {
       "version": "0.4.13",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-      "dev": true
+      "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -3553,6 +2358,11 @@
       "requires": {
         "is-extglob": "1.0.0"
       }
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE="
     },
     "is-number": {
       "version": "2.1.0",
@@ -4753,6 +3563,230 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
     },
+    "jsdom": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.3.0.tgz",
+      "integrity": "sha512-aPZTDl4MplzQhx5bLztk6nzjbEslmO3Q3+z0WpCMutL1XJDhZIRzir6R1Y8S84LgeT/7jhQvgtUMkY6oPwvlUw==",
+      "requires": {
+        "abab": "1.0.3",
+        "acorn": "5.2.1",
+        "acorn-globals": "4.1.0",
+        "array-equal": "1.0.0",
+        "content-type-parser": "1.0.1",
+        "cssom": "0.3.2",
+        "cssstyle": "0.2.37",
+        "domexception": "1.0.0",
+        "escodegen": "1.9.0",
+        "html-encoding-sniffer": "1.0.1",
+        "nwmatcher": "1.4.1",
+        "parse5": "3.0.3",
+        "pn": "1.0.0",
+        "request": "2.83.0",
+        "request-promise-native": "1.0.5",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.3",
+        "webidl-conversions": "4.0.2",
+        "whatwg-encoding": "1.0.1",
+        "whatwg-url": "6.3.0",
+        "xml-name-validator": "2.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+        },
+        "acorn-globals": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+          "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+          "requires": {
+            "acorn": "5.2.1"
+          }
+        },
+        "ajv": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+          "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+        },
+        "aws-sign2": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+        },
+        "boom": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "cryptiles": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.2.0"
+          },
+          "dependencies": {
+            "boom": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+              "requires": {
+                "hoek": "4.2.0"
+              }
+            }
+          }
+        },
+        "escodegen": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+          "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+          "requires": {
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.5.7"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+          "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+        },
+        "form-data": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.17"
+          }
+        },
+        "har-schema": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+        },
+        "har-validator": {
+          "version": "5.0.3",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "5.3.0",
+            "har-schema": "2.0.0"
+          }
+        },
+        "hawk": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+          "requires": {
+            "boom": "4.3.1",
+            "cryptiles": "3.1.2",
+            "hoek": "4.2.0",
+            "sntp": "2.1.0"
+          }
+        },
+        "hoek": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+        },
+        "http-signature": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "performance-now": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+        },
+        "request": {
+          "version": "2.83.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "requires": {
+            "aws-sign2": "0.7.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.1",
+            "har-validator": "5.0.3",
+            "hawk": "6.0.2",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "2.1.0",
+            "qs": "6.5.1",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
+          }
+        },
+        "sntp": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+          "requires": {
+            "hoek": "4.2.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "optional": true
+        },
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        }
+      }
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -4763,6 +3797,11 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+    },
+    "json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -4782,6 +3821,14 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
+    },
+    "jsonfile": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+      "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+      "requires": {
+        "graceful-fs": "4.1.11"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -4839,7 +3886,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
@@ -4886,6 +3932,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
       "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
     },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
@@ -4900,6 +3951,28 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
       "integrity": "sha1-FQzwoWeR9ZA7iJHqsVRgknS96lU="
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0",
+        "lodash.templatesettings": "4.1.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "requires": {
+        "lodash._reinterpolate": "3.0.0"
+      }
     },
     "longest": {
       "version": "1.0.1",
@@ -4932,6 +4005,14 @@
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.22.4",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.4.tgz",
+      "integrity": "sha512-kxBL06p6iO2qPBHsqGK2b3cRwiRGpnmSuVWNhwHcMX7qJOUr1HvricYP1LZOCdkQBUp0jiWg2d6WJwR3vYgByw==",
+      "requires": {
+        "vlq": "0.2.3"
       }
     },
     "makeerror": {
@@ -5195,8 +4276,7 @@
     "nwmatcher": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
-      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8=",
-      "dev": true
+      "integrity": "sha1-eumwew6oBNt+JfBctf5Al9TklJ8="
     },
     "oauth-sign": {
       "version": "0.8.2",
@@ -5262,7 +4342,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "0.1.3",
         "fast-levenshtein": "2.0.6",
@@ -5345,6 +4424,14 @@
         "error-ex": "1.3.1"
       }
     },
+    "parse5": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "requires": {
+        "@types/node": "8.0.52"
+      }
+    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -5367,8 +4454,7 @@
     "path-parse": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
-      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
       "version": "1.7.0",
@@ -5418,11 +4504,15 @@
         "pinkie": "2.0.4"
       }
     },
+    "pn": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pn/-/pn-1.0.0.tgz",
+      "integrity": "sha1-HPWjCw2AbNGPiPxBprXUrWFbO6k="
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "preserve": {
       "version": "0.2.0",
@@ -5662,6 +4752,34 @@
         "uuid": "3.1.0"
       }
     },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5671,6 +4789,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "right-align": {
       "version": "0.1.3",
@@ -5688,6 +4814,57 @@
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
       "requires": {
         "glob": "7.1.2"
+      }
+    },
+    "rollup": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.50.0.tgz",
+      "integrity": "sha512-7RqCBQ9iwsOBPkjYgoIaeUij606mSkDMExP0NT7QDI3bqkHYQHrQ83uoNIXwPcQm/vP2VbsUz3kiyZZ1qPlLTQ=="
+    },
+    "rollup-plugin-commonjs": {
+      "version": "8.2.5",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.5.tgz",
+      "integrity": "sha512-RxzILEgDOFvUgnuPVXNCfZ5f7Mv6RlQ1OyW925kmWRCgmV2V+g6G5qmKUmgW2HUQxp0YqqvRkqbez4Q/o6fRog==",
+      "requires": {
+        "acorn": "5.2.1",
+        "estree-walker": "0.5.0",
+        "magic-string": "0.22.4",
+        "resolve": "1.5.0",
+        "rollup-pluginutils": "2.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+        }
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
+      "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "builtin-modules": "1.1.1",
+        "is-module": "1.0.0",
+        "resolve": "1.5.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+      "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+      "requires": {
+        "estree-walker": "0.3.1",
+        "micromatch": "2.3.11"
+      },
+      "dependencies": {
+        "estree-walker": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+          "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao="
+        }
       }
     },
     "safe-buffer": {
@@ -5731,8 +4908,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scss-tokenizer": {
       "version": "0.2.3",
@@ -5889,6 +5065,11 @@
         "readable-stream": "2.3.3"
       }
     },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -5983,8 +5164,7 @@
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
-      "dev": true
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
     "tar": {
       "version": "2.2.1",
@@ -6084,15 +5264,25 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "1.1.2"
       }
     },
-    "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w=="
+    "uglify-es": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.1.6.tgz",
+      "integrity": "sha512-7zyH8T4rT3/iLVzNI7Oa8hVQSlv280S8y2/a2EmvEObft3067rdUJJKjBspc70d0HUk1Og1V5Ny4UgZOlZ0hSg==",
+      "requires": {
+        "commander": "2.11.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
@@ -6100,6 +5290,11 @@
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "dev": true,
       "optional": true
+    },
+    "universalify": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc="
     },
     "url-join": {
       "version": "2.0.2",
@@ -6143,6 +5338,11 @@
         }
       }
     },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
+    },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -6165,8 +5365,7 @@
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "websocket-driver": {
       "version": "0.7.0",
@@ -6188,9 +5387,33 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
       "integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
-      "dev": true,
       "requires": {
         "iconv-lite": "0.4.13"
+      }
+    },
+    "whatwg-url": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.3.0.tgz",
+      "integrity": "sha512-rM+hE5iYKGPAOu05mIdJR47pYSR2vDzfrTEFRc/S8D3L60yW8BuXmUJ7Kog7x/DrokFN7JNaHKadpzjouKRRAw==",
+      "requires": {
+        "lodash.sortby": "4.7.0",
+        "tr46": "1.0.1",
+        "webidl-conversions": "4.0.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+        },
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+          "requires": {
+            "punycode": "2.1.0"
+          }
+        }
       }
     },
     "which": {
@@ -6224,8 +5447,25 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "workbox-build": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-2.1.1.tgz",
+      "integrity": "sha512-YDgTur17Sm2dqpL7+y0+LYskgwi2kuUFZNIvVncuhwj4v2rnN18aBk/6MtHllDrWtozJl6NMbvvtgH2UNRBydg==",
+      "requires": {
+        "chalk": "1.1.3",
+        "fs-extra": "3.0.1",
+        "glob": "7.1.2",
+        "lodash.template": "4.4.0",
+        "mkdirp": "0.5.1",
+        "workbox-sw": "2.1.1"
+      }
+    },
+    "workbox-sw": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-2.1.1.tgz",
+      "integrity": "sha512-vweBw08fiup2ocJWMCpd2oFlVM5s9c1vdR9PzYkO8lUGNLDU+5vvMblpe3DRBZn11FABF0OriDb6AerXp1M2tw=="
     },
     "worker-farm": {
       "version": "1.5.0",
@@ -6265,8 +5505,7 @@
     "xml-name-validator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
-      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
-      "dev": true
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@stencil/dev-server": "latest",
     "@stencil/utils": "latest",
-    "@types/jest": "^21.1.1",
+    "@types/jest": "^21.1.6",
     "jest": "^21.2.1"
   },
   "repository": {


### PR DESCRIPTION
- Update npm dependencies to the latest versions.

Original bug issue https://github.com/ionic-team/stencil/issues/288 in the old version of `@stencil/core` affected the ability to run `npm run test`. With this refreshed set of npm dependencies, every package would be using the latest versions (as resolved by running of `npm install` and `npm update` commands on a freshly cloned starter repository).


Related to the issue:
https://github.com/ionic-team/stencil-app-starter/issues/28