### PR TITLE
[BUGFIX] Better gitignore settings for `www`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
-!www/favicon.ico
+www
+!www/.gitkeep
 
 *~
 *.sw[mnpcod]


### PR DESCRIPTION
Originally, the problem was that not having a `www` directory required
the developer to run the server twice. This was fixed by adding
a `.gitkeep` to `www` and removing `www` entirely from .gitignore.

This PR proposes a slightly different approach. It still ignores
`www` but whitelists `www/.gitkeep` (as it was doing already with
`favicon.ico`).

This also removes the whitelist for favicon as it is being removed by
the compiler and already lives in assets.

There is a caveat with this approach and it is that the compiler removes
all contents from the target directories. Expect a PR fixing this soon
in `stencil`.