### PR TITLE
Add jest types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "@stencil/core": "~0.14.1",
-    "@stencil/router": "~0.3.0"
+    "@stencil/router": "~0.3.0",
+    "@types/jest": "^23.3.8"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "@stencil/core": "~0.14.1",
-    "@stencil/router": "~0.3.0",
+    "@stencil/router": "~0.3.0"
+  },
+  "devDependencies": {
     "@types/jest": "^23.3.8"
   },
   "repository": {


### PR DESCRIPTION
Fixes errors thrown in WebStorm/IntelliJ for testing scripts.

I was getting errors thrown in IntelliJ when editing the testing files, and this seems to fix it.