### PR TITLE
chore(): add components.d.ts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist/
 !www/favicon.ico
 www/
+src/components.d.ts
 
 *~
 *.sw[mnpcod]


### PR DESCRIPTION
generated file, any reason why it should be versioned? I see that similar PR is already on component starter