### PR TITLE
Updates meta tag syntax for consistency

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
   <meta name="theme-color" content="#16161d">
   <meta name="apple-mobile-web-app-capable" content="yes">
-  <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
+  <meta http-equiv="x-ua-compatible" content="IE=Edge">
 
   <link href="/build/app.css" rel="stylesheet">
   <script src="/build/app.js"></script>


### PR DESCRIPTION
Of the five meta tags in the index.html, one was using non-self-closing-tag syntax and the others were not. Additionally, since this is html5 (not xhtml) self-closing tags are not necessary for void elements. This change makes all the meta tags consistent, and most correct.