### PR TITLE
 chore(testing): update puppeteer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,12 @@
     "generate": "stencil generate"
   },
   "devDependencies": {
-    "@stencil/core": "^2.0.0",
+    "@stencil/core": "^2.7.0",
     "@stencil/router": "^1.0.1",
     "@types/jest": "^26.0.24",
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
-    "puppeteer": "^5.5.0",
-    "@types/puppeteer": "^5.4.3"
+    "puppeteer": "^10.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
upgrade Stencil minimum version to v2.7.0

update puppeteer to v10.0.0 to support Stencil v2.7.0. puppeteer@10.0.0
includes it's own type definitions, requiring the removal of the
community driven ones