### PR TITLE
chore(tests): upgrate starter to jest 27

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "generate": "stencil generate"
   },
   "devDependencies": {
-    "@stencil/core": "^2.7.0",
+    "@stencil/core": "^2.13.0",
     "@stencil/router": "^1.0.1",
-    "@types/jest": "^26.0.24",
-    "jest": "^26.6.3",
-    "jest-cli": "^26.6.3",
+    "@types/jest": "^27.0.3",
+    "jest": "^27.4.5",
+    "jest-cli": "^27.4.5",
     "puppeteer": "^10.0.0"
   },
   "license": "MIT"


### PR DESCRIPTION
## Changes:

update the stencil app starter to jest 27 by upgrading jest, jest typings, 
and the jest-cli. this upgrade requires the latest version of stencil,
whose minimum version is/will be updated to v2.13.0


## Testing:
There are two parts to testing this change. Because we intend to release the changes in this PR at the same time Stencil v2.13.0 is released, we first have to build a pre-release of Stencil that includes support for Jest 27

### Build a pre-release of Stencil
1. Clone the [Stencil repo](https://github.com/ionic-team/stencil/)
    1. Ensure that https://github.com/ionic-team/stencil/commit/10efeb6f74888f05a13a47d8afc00b5e83a3f3db is in your local copy of `main` (`git branch --contains 10efeb6f74888f05a13a47d8afc00b5e83a3f3db` should return 'main'). If it doesn't, try `git pull`'ing
2. `cd` to the Stencil repo, and build a tarball for the compiler
    1.  `npm ci && npm run build && npm pack` will create a tarball at the root of your Stencil repo clone with the name 'stencil-core-2.12.1.tgz'

### Test the Starter
1. clone this repo, and check out this branch: `git clone https://github.com/ionic-team/stencil-app-starter.git && cd stencil-app-starter && git checkout jest-27`
2. `npm i PATH_TO_YOUR_TARBALL`
3. `npm run build` - expect the build to pass
4. `npm t` - expect tests to pass (although you'll see warnings about immutable props being mutated)