### PR TITLE
fix(build): temporarily pin stencil version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "generate": "stencil generate"
   },
   "devDependencies": {
-    "@stencil/core": "^2.13.0",
+    "@stencil/core": "2.13.0",
     "@stencil/router": "^1.0.1",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",


### PR DESCRIPTION
this commit temporarily pins the stencil version to v2.13.0.
in v2.14.0, we upgraded typescript to v4.5.4, which is now 
causing issues with the typings found in `@stencil/router` v1